### PR TITLE
fix(v1): update peer dependency version range for svelte 5 prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0"
+    "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0 || ^5.0.0-next.1"
   },
   "devDependencies": {
     "@floating-ui/dom": "^1.6.3",


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description
<!-- Add a brief description of the pr -->
We received a report (https://github.com/huntabyte/shadcn-svelte/issues/831#issuecomment-2295583361) where installs with `npm` are failing as the peer dependency version range requirements aren't being met.

To fix, `^5.0.0-next.1` was added to the version range. 

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->